### PR TITLE
Laravel 8 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.2
+          php-version: 7.3
           tools: composer:v2
           coverage: xdebug
 
@@ -45,7 +45,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.2
+          php-version: 7.3
           tools: composer:v2
           coverage: xdebug
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        laravel: [5.5.*, 5.6.*, 5.7.*, 5.8.*, 6.*, 7.*]
+        laravel: [5.5.*, 5.6.*, 5.7.*, 5.8.*, 6.*, 7.*, 8.*]
     name: Tests for Laravel ${{ matrix.laravel }}
     steps:
       - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "illuminate/validation": "^5.5 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
-        "guzzlehttp/guzzle": "^7.0.1",
+        "guzzlehttp/guzzle": "^6.5 || ^7.0.1",
         "mockery/mockery": "^1.3",
         "phpunit/phpunit": "^8.5",
         "symfony/var-exporter": "^4.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "illuminate/contracts": "^5.5 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/validation": "^5.5 || ^6.0 || ^7.0 || ^8.0"

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/contracts": "^5.5 || ^6.0 || ^7.0",
-        "illuminate/support": "^5.5 || ^6.0 || ^7.0",
-        "illuminate/validation": "^5.5 || ^6.0 || ^7.0"
+        "illuminate/contracts": "^5.5 || ^6.0 || ^7.0 || ^8.0",
+        "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0",
+        "illuminate/validation": "^5.5 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^7.0.1",
         "mockery/mockery": "^1.3",
         "phpunit/phpunit": "^8.5",
         "symfony/var-exporter": "^4.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.2",
         "illuminate/contracts": "^5.5 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/validation": "^5.5 || ^6.0 || ^7.0 || ^8.0"


### PR DESCRIPTION
Add Laravel version 8 components to dependencies. 

Laravel 8 requires Guzzle version 7. This project only utilizes Guzzle in the `bin/generate-resources` script and it doesn't seem to contain anything that would introduce compatibility issues. 

Resources generate fine and all Laravel integration tests are passing. Lumen 8 is not yet available to test. 