### PR TITLE
Improve support for Canary Islands

### DIFF
--- a/src/PostalCodeValidator.php
+++ b/src/PostalCodeValidator.php
@@ -108,13 +108,15 @@ class PostalCodeValidator
     {
         $countryCode = strtoupper($countryCode);
 
-        if (array_key_exists($countryCode, self::ALIASES)) {
-            $countryCode = self::ALIASES[$countryCode];
-        }
-
-        return $this->patternOverrides[$countryCode]
+        $pattern = $this->patternOverrides[$countryCode]
             ?? $this->patterns[$countryCode]
             ?? null;
+
+        if ($pattern === null && array_key_exists($countryCode, self::ALIASES) &&  $countryCode !== self::ALIASES[$countryCode]) {
+            $pattern = $this->patternFor(self::ALIASES[$countryCode]);
+        }
+
+        return $pattern;
     }
 
     /**

--- a/tests/Unit/PostalCodeValidatorTest.php
+++ b/tests/Unit/PostalCodeValidatorTest.php
@@ -47,6 +47,13 @@ class PostalCodeValidatorTest extends TestCase
         $this->assertTrue($this->validator->passes('IC', '38580'));
     }
 
+    public function testCanaryIslandsCanOverridden(): void
+    {
+        $this->validator->override('IC', '/^(?:00000)$/');
+
+        $this->assertFalse($this->validator->passes('IC', '38580'));
+    }
+
     /**
      * Test if the shipped examples pass validation.
      *


### PR DESCRIPTION
Hi,

This pull request is related to #35.

Previously, I used this configuration to support the Canary Islands:
```php
\PostalCodes::override([
            'IC' => '/^(?:(35|38)\d{3})$/',
]);
```

It allowed me to check codes like this:
```php
$inCanaryIslands = \PostalCodes::passes('IC', $code);
```

However, it stopped working. after updating to [v3.7.0](https://github.com/axlon/laravel-postal-code-validation/releases/tag/v3.7.0)+.

This PR restores that behaviour and makes the postal code pattern more restrictive, ensuring that only codes starting with 35 or 38 are considered valid ([source](https://www.ine.es/daco/daco42/codmun/cod_islas.htm)).